### PR TITLE
Accept "sso" tag

### DIFF
--- a/src/main/java/io/pivotal/spring/cloud/SsoServiceInfo.java
+++ b/src/main/java/io/pivotal/spring/cloud/SsoServiceInfo.java
@@ -10,7 +10,11 @@ public class SsoServiceInfo extends BaseServiceInfo {
     private String authDomain;
 
     public SsoServiceInfo(String clientId, String clientSecret, String authDomain) {
-        super(P_SSO_ID);
+        this(P_SSO_ID, clientId, clientSecret, authDomain);
+    }
+
+    public SsoServiceInfo(String id, String clientId, String clientSecret, String authDomain) {
+        super(id);
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.authDomain = authDomain;

--- a/src/main/java/io/pivotal/spring/cloud/SsoServiceInfoCreator.java
+++ b/src/main/java/io/pivotal/spring/cloud/SsoServiceInfoCreator.java
@@ -8,12 +8,12 @@ import java.util.Map;
 public class SsoServiceInfoCreator extends CloudFoundryServiceInfoCreator<SsoServiceInfo> {
 
     public SsoServiceInfoCreator() {
-        super(new Tags());
+        super(new Tags("sso"));
     }
 
     @Override
     public boolean accept(Map<String, Object> serviceData) {
-        return serviceData.get("label").equals(SsoServiceInfo.P_SSO_ID);
+        return serviceData.get("label").equals(SsoServiceInfo.P_SSO_ID) || tagsMatch(serviceData);
     }
 
     @Override
@@ -22,6 +22,12 @@ public class SsoServiceInfoCreator extends CloudFoundryServiceInfoCreator<SsoSer
         String clientId = (String) credentials.get("client_id");
         String clientSecret = (String) credentials.get("client_secret");
         String authDomain = (String) credentials.get("auth_domain");
-        return new SsoServiceInfo(clientId, clientSecret, authDomain);
+        if (serviceData.get("label").equals(SsoServiceInfo.P_SSO_ID)) {
+            // to keep backward compatibility
+            return new SsoServiceInfo(clientId, clientSecret, authDomain);
+        } else {
+            String id = (String) serviceData.get("name");
+            return new SsoServiceInfo(id, clientId, clientSecret, authDomain);
+        }
     }
 }

--- a/src/test/java/io/pivotal/spring/cloud/SsoServiceInfoCreatorIntegrationTests.java
+++ b/src/test/java/io/pivotal/spring/cloud/SsoServiceInfoCreatorIntegrationTests.java
@@ -21,6 +21,15 @@ public class SsoServiceInfoCreatorIntegrationTests extends AbstractCloudFoundryC
         assertServiceFoundOfType(serviceInfos, "p-identity", SsoServiceInfo.class);
     }
 
+    @Test
+    public void ssoServiceCreationWithSsoTag() {
+        when(mockEnvironment.getEnvValue(VCAP_SERVICES_ENV_KEY))
+                .thenReturn(getServicesPayload(getSsoServicePayloadWithSsoTag()));
+
+        List<ServiceInfo> serviceInfos = testCloudConnector.getServiceInfos();
+        assertServiceFoundOfType(serviceInfos, "test-sso", SsoServiceInfo.class);
+    }
+
     private String getSsoServicePayload() {
         String payload = "{\n" +
             "    \"name\": \"test-sso\",\n" +
@@ -35,6 +44,24 @@ public class SsoServiceInfoCreatorIntegrationTests extends AbstractCloudFoundryC
             "        \"client_secret\": \"its_a_secret_dont_tell\"\n" +
             "    }\n" +
             "}";
+
+        return payload;
+    }
+
+    private String getSsoServicePayloadWithSsoTag() {
+        String payload = "{\n" +
+                "    \"name\": \"test-sso\",\n" +
+                "    \"label\": \"p-foo\",\n" +
+                "    \"plan\": \"standard\",\n" +
+                "    \"tags\": [\n" +
+                "        \"sso\", \"oauth2\"\n" +
+                "    ],\n" +
+                "    \"credentials\": {\n" +
+                "        \"auth_domain\": \"http://test.com\",\n" +
+                "        \"client_id\": \"config_client_id\",\n" +
+                "        \"client_secret\": \"its_a_secret_dont_tell\"\n" +
+                "    }\n" +
+                "}";
 
         return payload;
     }

--- a/src/test/java/io/pivotal/spring/cloud/SsoServiceInfoCreatorTests.java
+++ b/src/test/java/io/pivotal/spring/cloud/SsoServiceInfoCreatorTests.java
@@ -2,6 +2,7 @@ package io.pivotal.spring.cloud;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,8 +23,24 @@ public class SsoServiceInfoCreatorTests {
     }
 
     @Test
+    public void acceptServiceDataForTags() {
+        Map<String, Object> serviceData = new HashMap<>();
+        serviceData.put("tags", Arrays.asList("sso", "oauth2"));
+        serviceData.put("label", "p-foo");
+        assertTrue(creator.accept(serviceData));
+    }
+
+    @Test
     public void doesNotAcceptServiceData() {
         Map<String, Object> serviceData = new HashMap<>();
+        serviceData.put("label", "wrong-label");
+        assertFalse(creator.accept(serviceData));
+    }
+
+    @Test
+    public void doesNotAcceptServiceDataForTags() {
+        Map<String, Object> serviceData = new HashMap<>();
+        serviceData.put("tags", Arrays.asList("oauth2"));
         serviceData.put("label", "wrong-label");
         assertFalse(creator.accept(serviceData));
     }
@@ -37,6 +54,7 @@ public class SsoServiceInfoCreatorTests {
 
         Map<String, Object> serviceData = new HashMap<>();
         serviceData.put("credentials", credentials);
+        serviceData.put("label", P_SSO_ID);
 
         SsoServiceInfo info = creator.createServiceInfo(serviceData);
 


### PR DESCRIPTION
I'm developing a service broker compatible with Single Sign-On for PCF.
https://github.com/maki-home/uaa

Because spring-cloud-sso-connector only accepts the service whose name is `p-identity`, my service broker can't leverage with this connector.

This commit allows this connector to accept services which contains `sso` in the tags.
