### PR TITLE
prevent TokenStore from loading when required properties are not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .project
 .settings
 .classpath
+
+out/

--- a/src/main/java/io/pivotal/spring/cloud/IssuerCheckConfiguration.java
+++ b/src/main/java/io/pivotal/spring/cloud/IssuerCheckConfiguration.java
@@ -1,6 +1,7 @@
 package io.pivotal.spring.cloud;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.discovery.ProviderConfiguration;
@@ -12,6 +13,7 @@ import org.springframework.security.oauth2.provider.token.store.jwk.JwkTokenStor
 import java.net.MalformedURLException;
 
 @Configuration
+@ConditionalOnProperty({"ssoServiceUrl", "security.oauth2.resource.jwk.key-set-uri"})
 public class IssuerCheckConfiguration {
     @Value("${ssoServiceUrl}")
     private String ssoServiceUrl;

--- a/src/test/java/io/pivotal/spring/cloud/IssuerCheckConfigurationLocalTest.java
+++ b/src/test/java/io/pivotal/spring/cloud/IssuerCheckConfigurationLocalTest.java
@@ -1,0 +1,33 @@
+package io.pivotal.spring.cloud;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = IssuerCheckConfiguration.class)
+public class IssuerCheckConfigurationLocalTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void testJwkTokenStoreNotFoundInContext() {
+        thrown.expect(NoSuchBeanDefinitionException.class);
+        thrown.expectMessage("No qualifying bean of type 'org.springframework.security.oauth2.provider.token.TokenStore' available");
+
+        applicationContext.getBean( TokenStore.class );
+
+    }
+
+}


### PR DESCRIPTION
This is to enable local development while the SSO connector exists on the classpath